### PR TITLE
fix: improve audio initialization for iOS devices

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -192,7 +192,14 @@ export default function Home() {
           {allSongs.map((song) => (
             <button
               key={song.id}
-              onClick={() => {
+              onClick={async () => {
+                // Start audio context on user interaction (iOS requirement)
+                try {
+                  const Tone = await import('tone');
+                  await Tone.start();
+                } catch (e) {
+                  console.error('Failed to start audio context:', e);
+                }
                 setCurrentSong(song);
                 setHasStarted(true);
               }}

--- a/src/hooks/usePianoAudio.ts
+++ b/src/hooks/usePianoAudio.ts
@@ -299,13 +299,23 @@ export function usePianoAudio(source: SongSource) {
 
     // Controls
     const togglePlay = async () => {
-        await Tone.start();
-        if (Tone.Transport.state === "started") {
-            Tone.Transport.pause();
-            setState((prev) => ({ ...prev, isPlaying: false }));
-        } else {
-            Tone.Transport.start();
-            setState((prev) => ({ ...prev, isPlaying: true }));
+        try {
+            await Tone.start();
+
+            // Explicitly resume context if suspended (iOS fix)
+            if (Tone.context.state === 'suspended') {
+                await Tone.context.resume();
+            }
+
+            if (Tone.Transport.state === "started") {
+                Tone.Transport.pause();
+                setState((prev) => ({ ...prev, isPlaying: false }));
+            } else {
+                Tone.Transport.start();
+                setState((prev) => ({ ...prev, isPlaying: true }));
+            }
+        } catch (error) {
+            console.error('Audio playback error:', error);
         }
     };
 


### PR DESCRIPTION
Fixes audio playback issues on iPhone by initializing audio context earlier and adding iOS-specific handling. Audio context is now started when user selects a song (early user gesture) and includes explicit context.resume() for iOS. All E2E tests passing (7/7).