### PR TITLE
🛡️ Sentinel: Add file upload validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Application lacked a Content Security Policy (CSP), exposing it to XSS.
 **Learning:** Next.js `output: "export"` ignores `next.config.js` headers and `metadata` API doesn't support `http-equiv` meta tags.
 **Prevention:** Manually inject `<meta http-equiv="Content-Security-Policy" ...>` in the root `layout.tsx` for static exports.
+
+## 2026-01-24 - Untestable File Validation
+**Vulnerability:** File upload logic was tightly coupled to the DOM `File` API, making unit testing difficult and leading to weak client-side validation.
+**Learning:** Decoupling validation logic using a `FileLike` interface (name, size) allows robust unit testing without mocking DOM globals.
+**Prevention:** Always extract validation logic into pure functions accepting plain objects/interfaces rather than DOM types.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Waterfall } from "@/components/piano/Waterfall";
 import { Controls } from "@/components/piano/Controls";
 import { MusicXMLParser } from "@/lib/musicxml/parser";
 import { MIDIGenerator } from "@/lib/musicxml/midi-generator";
+import { validateMusicXMLFile } from "@/lib/validation";
 import * as Tone from "tone";
 
 const BASE_PATH = '/piano_lessons';
@@ -279,38 +280,40 @@ export default function Home() {
     if (!file) return;
 
 
-    if (file.name.endsWith('.xml') || file.name.endsWith('.musicxml')) {
-      try {
-        const text = await file.text();
+    const validation = validateMusicXMLFile(file);
+    if (!validation.valid) {
+      alert(validation.error);
+      return;
+    }
 
-        // 1. Parse MusicXML
-        const parser = new MusicXMLParser();
-        const score = parser.parse(text);
+    try {
+      const text = await file.text();
 
-        // 2. Generate MIDI
-        const generator = new MIDIGenerator();
-        const midiBase64 = generator.generate(score);
-        const midiUrl = `data:audio/midi;base64,${midiBase64}`;
+      // 1. Parse MusicXML
+      const parser = new MusicXMLParser();
+      const score = parser.parse(text);
 
-        const newSong: Song = {
-          id: `upload-${Date.now()}`,
-          title: score.title || file.name.replace(/\.(xml|musicxml)$/i, ''),
-          artist: 'Uploaded (MusicXML)',
-          url: midiUrl,
-          type: 'midi'
-        };
+      // 2. Generate MIDI
+      const generator = new MIDIGenerator();
+      const midiBase64 = generator.generate(score);
+      const midiUrl = `data:audio/midi;base64,${midiBase64}`;
 
-        setAllSongs(prev => [...prev, newSong]);
-        saveToLocalStorage(newSong);
-        setCurrentSong(newSong);
-        setHasStarted(true);
+      const newSong: Song = {
+        id: `upload-${Date.now()}`,
+        title: score.title || file.name.replace(/\.(xml|musicxml)$/i, ''),
+        artist: 'Uploaded (MusicXML)',
+        url: midiUrl,
+        type: 'midi'
+      };
 
-      } catch (error) {
-        console.error('Error converting MusicXML:', error);
-        alert(error instanceof Error ? error.message : 'Failed to convert file');
-      }
-    } else {
-      alert("Please upload a .xml or .musicxml file.");
+      setAllSongs(prev => [...prev, newSong]);
+      saveToLocalStorage(newSong);
+      setCurrentSong(newSong);
+      setHasStarted(true);
+
+    } catch (error) {
+      console.error('Error converting MusicXML:', error);
+      alert(error instanceof Error ? error.message : 'Failed to convert file');
     }
   };
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,44 @@
+/**
+ * Validation utilities for user inputs
+ */
+
+export interface FileLike {
+    name: string;
+    size: number;
+}
+
+const MAX_FILE_SIZE_MB = 5;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+const ALLOWED_EXTENSIONS = ['.xml', '.musicxml'];
+
+export interface ValidationResult {
+    valid: boolean;
+    error?: string;
+}
+
+export function validateMusicXMLFile(file: FileLike): ValidationResult {
+    if (!file) {
+        return { valid: false, error: "No file provided." };
+    }
+
+    // 1. Check File Size
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+        return {
+            valid: false,
+            error: `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`
+        };
+    }
+
+    // 2. Check Extension (Case-insensitive)
+    const lowerName = file.name.toLowerCase();
+    const hasValidExtension = ALLOWED_EXTENSIONS.some(ext => lowerName.endsWith(ext));
+
+    if (!hasValidExtension) {
+        return {
+            valid: false,
+            error: "Invalid file type. Please upload a .xml or .musicxml file."
+        };
+    }
+
+    return { valid: true };
+}

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { validateMusicXMLFile } from '../../src/lib/validation';
+
+describe('validateMusicXMLFile', () => {
+    it('should validate a correct file', () => {
+        const file = { name: 'song.xml', size: 1000 };
+        const result = validateMusicXMLFile(file);
+        expect(result.valid).toBe(true);
+    });
+
+    it('should validate a correct .musicxml file', () => {
+        const file = { name: 'song.musicxml', size: 1000 };
+        const result = validateMusicXMLFile(file);
+        expect(result.valid).toBe(true);
+    });
+
+    it('should allow uppercase extensions', () => {
+        const file = { name: 'SONG.XML', size: 1000 };
+        const result = validateMusicXMLFile(file);
+        expect(result.valid).toBe(true);
+    });
+
+    it('should reject a file that is too large', () => {
+        const file = { name: 'song.xml', size: 6 * 1024 * 1024 }; // 6MB
+        const result = validateMusicXMLFile(file);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('too large');
+    });
+
+    it('should reject invalid extensions', () => {
+        const file = { name: 'song.txt', size: 1000 };
+        const result = validateMusicXMLFile(file);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('Invalid file type');
+    });
+
+    it('should handle null file', () => {
+        // @ts-expect-error Testing runtime check
+        const result = validateMusicXMLFile(null);
+        expect(result.valid).toBe(false);
+    });
+});


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure file upload handling

🚨 Severity: MEDIUM
💡 Vulnerability: The file upload handler blindly accepted any file ending in `.xml` or `.musicxml` without checking file size, potentially allowing DoS attacks via massive files. It also coupled logic to the DOM, making it hard to test.
🎯 Impact: A user could upload a massive file, crashing the browser tab (DoS).
🔧 Fix: Implemented a dedicated `validateMusicXMLFile` function with a 5MB limit and case-insensitive extension checking. Extracted this to a pure function for testing.
✅ Verification: Added unit tests covering valid/invalid files, size limits, and edge cases. Manual verification via `npm test` passed.

---
*PR created automatically by Jules for task [8665534937377648833](https://jules.google.com/task/8665534937377648833) started by @pimooss*