### PR TITLE
🎨 Palette: Accessible Sliders & Note Labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,8 @@
+# Palette's Journal
+
+This document records critical UX and accessibility learnings for the Piano Lessons project.
+
+## 2024-05-23 - Accessibility First
+
+**Learning:** This project uses custom range sliders for musical parameters. Standard range inputs lack semantic context for musical values (e.g., "60" vs "C4").
+**Action:** Always implement `aria-valuetext` for any slider that represents a non-numeric concept (like notes) or formatted values (like "1.5x").

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    if (isNaN(midi)) return "Unknown";
+    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const octave = Math.floor(midi / 12) - 1;
+    const note = notes[midi % 12];
+    return `${note}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('converts C4 (60) correctly', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('converts A0 (21) correctly', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('converts C8 (108) correctly', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('converts sharps correctly (61 -> C#4)', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('handles NaN safely', () => {
+        expect(getNoteName(NaN)).toBe('Unknown');
+    });
+});


### PR DESCRIPTION
Implemented accessibility improvements for range sliders in the Controls component. Added ARIA labels and human-readable value text (e.g., "C4", "1.5x") to ensure screen readers provide meaningful context. Also fixed the visual label for the Split Point slider to correctly display note names (e.g., C#4) instead of incorrectly labeling everything as C. Validated with unit tests and frontend verification.

---
*PR created automatically by Jules for task [4348293554450378953](https://jules.google.com/task/4348293554450378953) started by @pimooss*