### PR TITLE
🎨 Palette: Improve accessibility of Split Point slider

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Dynamic Range Slider Labels
+**Learning:** Range sliders representing complex values (like MIDI notes) need dynamic `aria-valuetext` and visual labels to be accessible and usable. Raw numbers are insufficient.
+**Action:** Always implement a helper function (like `getNoteName`) to convert raw values to human-readable strings for both visual display and `aria-valuetext`.

--- a/dev_output.log
+++ b/dev_output.log
@@ -1,0 +1,17 @@
+
+> piano_lessons@0.3.0 dev
+> next dev
+
+▲ Next.js 16.1.3 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+✓ Ready in 1050ms
+○ Compiling / ...
+ GET / 200 in 15.6s (compile: 15.0s, render: 594ms)

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point"
+                                                    aria-valuetext={`Split point ${getNoteName(visualSettings.splitPoint)}`}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const octave = Math.floor(midi / 12) - 1;
+    const noteIndex = midi % 12;
+    return `${notes[noteIndex]}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('formats Middle C (60) correctly', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('formats lowest note (0) correctly', () => {
+        expect(getNoteName(0)).toBe('C-1');
+    });
+
+    it('formats sharps correctly', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('formats high notes correctly', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('formats A440 correctly', () => {
+        expect(getNoteName(69)).toBe('A4');
+    });
+});


### PR DESCRIPTION
This PR improves the accessibility and usability of the "Split Point" and "Playback Speed" sliders in the `Controls` component.

Changes:
1.  **Correct Note Labeling:** The Split Point slider now uses a new `getNoteName` utility to display the exact note name (e.g., "C#4") instead of incorrectly labeling every note as "C".
2.  **Accessibility:**
    *   Added `aria-label` to the Split Point slider.
    *   Added `aria-valuetext` to the Split Point slider (announces "Split point C4").
    *   Added `aria-valuetext` to the Playback Speed slider (announces "1.5x").
3.  **Testing:** Added unit tests for the `getNoteName` function in `tests/unit/getNoteName.test.ts`.

These changes ensure that screen reader users get meaningful feedback when adjusting these settings, and all users see accurate note information.

---
*PR created automatically by Jules for task [188166596320464012](https://jules.google.com/task/188166596320464012) started by @pimooss*