### PR TITLE
🎨 Palette: Accessible sliders and note names

### DIFF
--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point note"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const octave = Math.floor(midi / 12) - 1;
+    const note = NOTES[midi % 12];
+    return `${note}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('returns C4 for MIDI 60', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('returns A0 for MIDI 21', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('returns C8 for MIDI 108', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('returns correct sharp notes', () => {
+        expect(getNoteName(61)).toBe('C#4');
+        expect(getNoteName(66)).toBe('F#4');
+    });
+
+    it('handles low MIDI notes', () => {
+        expect(getNoteName(0)).toBe('C-1');
+    });
+});


### PR DESCRIPTION
*   💡 What: Added `aria-label` and `aria-valuetext` to split point and playback rate sliders. Added `getNoteName` utility.
*   🎯 Why: To make sliders accessible to screen readers and show correct note names (e.g., C#4) instead of raw numbers.
*   ♿ Accessibility: Screen readers now announce "C4" or "1.5x speed" instead of "60" or "1.5".
*   📸 Verified with Playwright screenshot.

---
*PR created automatically by Jules for task [10966985719033011499](https://jules.google.com/task/10966985719033011499) started by @pimooss*