### PR TITLE
🎨 Palette: Improved Controls Accessibility and Labels

### DIFF
--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const octave = Math.floor(midi / 12) - 1;
+    const noteIndex = midi % 12;
+    return `${NOTES[noteIndex]}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('formats Middle C (60) correctly', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('formats A440 (69) correctly', () => {
+        expect(getNoteName(69)).toBe('A4');
+    });
+
+    it('formats lowest MIDI note (21) correctly', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('formats highest MIDI note (108) correctly', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('formats sharps correctly', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('formats negatives correctly (theoretical)', () => {
+        expect(getNoteName(0)).toBe('C-1');
+    });
+});


### PR DESCRIPTION
🎨 Palette: Improved Controls Accessibility and Labels

💡 **What:**
- Added a `getNoteName` utility to correctly format MIDI numbers as musical notes (e.g., "61 (C#4)").
- Updated the "Split Point" slider visual label to use this utility, fixing the issue where all notes were labeled as "C".
- Added `aria-valuetext` to the Playback Speed slider (e.g., "1.5x speed") and Split Point slider (e.g., "C#4") for screen readers.
- Added `aria-label` to the Split Point slider.

🎯 **Why:**
- Screen reader users had no context for the slider values ("1.5" or "60").
- Visual users saw incorrect note labels (everything was labeled "C").

📸 **Before/After:**
- Before: Split Point label "61 (C4)" (Incorrect).
- After: Split Point label "61 (C#4)" (Correct).

♿ **Accessibility:**
- Sliders now announce meaningful values via `aria-valuetext`.
- Split point slider has an accessible name.

---
*PR created automatically by Jules for task [4842508710485808617](https://jules.google.com/task/4842508710485808617) started by @pimooss*