### PR TITLE
🛡️ Sentinel: [MEDIUM] Validate persisted song data to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** File upload logic was tightly coupled to the DOM `File` API, making unit testing difficult and leading to weak client-side validation.
 **Learning:** Decoupling validation logic using a `FileLike` interface (name, size) allows robust unit testing without mocking DOM globals.
 **Prevention:** Always extract validation logic into pure functions accepting plain objects/interfaces rather than DOM types.
+
+## 2026-01-27 - Unvalidated Persistence
+**Vulnerability:** Data loaded from `localStorage` was cast to `Song[]` without validation, allowing potential XSS or app crash if storage was tampered with.
+**Learning:** Persisted client-side data (localStorage/IndexedDB) is untrusted input just like network requests.
+**Prevention:** Always validate and sanitize data retrieved from client-side storage before using it in the application state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "piano_lessons",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "piano_lessons",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@tonejs/midi": "^2.0.28",
         "abcjs": "^6.6.0",
@@ -79,7 +79,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1696,7 +1695,6 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -2441,7 +2439,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2452,7 +2449,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2512,7 +2508,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3133,7 +3128,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3449,7 +3443,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -3514,7 +3507,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4150,7 +4142,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4336,7 +4327,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4780,7 +4770,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6670,7 +6659,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6680,7 +6668,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7485,7 +7472,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7668,7 +7654,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7809,7 +7794,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7918,7 +7902,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8175,7 +8158,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,20 +7,10 @@ import { Waterfall } from "@/components/piano/Waterfall";
 import { Controls } from "@/components/piano/Controls";
 import { MusicXMLParser } from "@/lib/musicxml/parser";
 import { MIDIGenerator } from "@/lib/musicxml/midi-generator";
-import { validateMusicXMLFile } from "@/lib/validation";
+import { validateMusicXMLFile, validateSong, Song } from "@/lib/validation";
 import * as Tone from "tone";
 
 const BASE_PATH = '/piano_lessons';
-
-// Song Management
-interface Song {
-  id: string;
-  title: string;
-  artist: string;
-  url?: string;
-  abc?: string;
-  type: 'midi' | 'abc';
-}
 
 const defaultSongs: Song[] = [
   { id: 'gnossienne1', title: 'Gnossienne No. 1', artist: 'Erik Satie', url: `${BASE_PATH}/gnossienne1.mid`, type: 'midi' },
@@ -251,12 +241,18 @@ export default function Home() {
     try {
       const saved = localStorage.getItem('piano_lessons_uploads');
       if (saved) {
-        const uploadedSongs = JSON.parse(saved) as Song[];
-        // Deduplicate
-        const defaultIds = new Set(defaultSongs.map(s => s.id));
-        const newUploads = uploadedSongs.filter(u => !defaultIds.has(u.id));
-        if (newUploads.length > 0) {
-          setAllSongs((prev: Song[]) => [...prev, ...newUploads]);
+        const parsed = JSON.parse(saved);
+        if (Array.isArray(parsed)) {
+          // Validate structure
+          const validSongs = parsed.filter(validateSong);
+
+          // Deduplicate
+          const defaultIds = new Set(defaultSongs.map(s => s.id));
+          const newUploads = validSongs.filter(u => !defaultIds.has(u.id));
+
+          if (newUploads.length > 0) {
+            setAllSongs((prev: Song[]) => [...prev, ...newUploads]);
+          }
         }
       }
     } catch (e: unknown) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -42,3 +42,38 @@ export function validateMusicXMLFile(file: FileLike): ValidationResult {
 
     return { valid: true };
 }
+
+export interface Song {
+  id: string;
+  title: string;
+  artist: string;
+  url?: string;
+  abc?: string;
+  type: 'midi' | 'abc';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validateSong(song: any): song is Song {
+    if (!song || typeof song !== 'object') return false;
+
+    // Required fields
+    if (typeof song.id !== 'string') return false;
+    if (typeof song.title !== 'string') return false;
+    if (typeof song.artist !== 'string') return false;
+    if (song.type !== 'midi' && song.type !== 'abc') return false;
+
+    // Optional fields
+    if (song.url !== undefined && typeof song.url !== 'string') return false;
+    if (song.abc !== undefined && typeof song.abc !== 'string') return false;
+
+    // Security Check: URL
+    if (song.url) {
+        const url = song.url.toLowerCase().trim();
+        // Prevent XSS via javascript: protocol
+        if (url.startsWith('javascript:') || url.startsWith('vbscript:')) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateMusicXMLFile } from '../../src/lib/validation';
+import { validateMusicXMLFile, validateSong } from '../../src/lib/validation';
 
 describe('validateMusicXMLFile', () => {
     it('should validate a correct file', () => {
@@ -38,5 +38,87 @@ describe('validateMusicXMLFile', () => {
         // @ts-expect-error Testing runtime check
         const result = validateMusicXMLFile(null);
         expect(result.valid).toBe(false);
+    });
+});
+
+describe('validateSong', () => {
+    it('should validate a correct MIDI song', () => {
+        const song = {
+            id: '1',
+            title: 'Test',
+            artist: 'Me',
+            type: 'midi',
+            url: 'https://example.com/song.mid'
+        };
+        expect(validateSong(song)).toBe(true);
+    });
+
+    it('should validate a correct ABC song', () => {
+        const song = {
+            id: '2',
+            title: 'Test ABC',
+            artist: 'Me',
+            type: 'abc',
+            abc: 'C D E F'
+        };
+        expect(validateSong(song)).toBe(true);
+    });
+
+    it('should reject non-objects', () => {
+        expect(validateSong(null)).toBe(false);
+        expect(validateSong('string')).toBe(false);
+    });
+
+    it('should reject missing required fields', () => {
+        const song = {
+            // id missing
+            title: 'Test',
+            artist: 'Me',
+            type: 'midi'
+        };
+        expect(validateSong(song)).toBe(false);
+    });
+
+    it('should reject invalid types', () => {
+        const song = {
+            id: '1',
+            title: 'Test',
+            artist: 'Me',
+            type: 'mp3' // Invalid
+        };
+        expect(validateSong(song)).toBe(false);
+    });
+
+    it('should reject malicious URLs (javascript:)', () => {
+        const song = {
+            id: '1',
+            title: 'Hacked',
+            artist: 'Hacker',
+            type: 'midi',
+            url: 'javascript:alert(1)'
+        };
+        expect(validateSong(song)).toBe(false);
+    });
+
+    it('should reject malicious URLs (vbscript:)', () => {
+        const song = {
+            id: '1',
+            title: 'Hacked',
+            artist: 'Hacker',
+            type: 'midi',
+            url: 'vbscript:msgbox "pwned"'
+        };
+        expect(validateSong(song)).toBe(false);
+    });
+
+    it('should allow data URLs', () => {
+        const song = {
+            id: '1',
+            title: 'Generated',
+            artist: 'App',
+            type: 'midi',
+            url: 'data:audio/midi;base64,TVRo...'
+        };
+        expect(validateSong(song)).toBe(true);
     });
 });


### PR DESCRIPTION
Implemented strict validation for song data loaded from `localStorage`.
Previously, the application parsed JSON from `localStorage` and cast it to `Song[]` without validation. This could allow XSS if `url` contained `javascript:` or cause crashes if the structure was invalid.

Changes:
- Moved `Song` interface to `src/lib/validation.ts`.
- Added `validateSong` type predicate which checks field types and sanitizes `url`.
- Updated `src/app/page.tsx` to filter persisted songs using `validateSong`.
- Added comprehensive unit tests in `tests/unit/validation.test.ts`.


---
*PR created automatically by Jules for task [15951432437868849387](https://jules.google.com/task/15951432437868849387) started by @pimooss*