### PR TITLE
🎨 Palette: Improve slider accessibility and note labeling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-19 - Accessible Range Sliders
+**Learning:** Range inputs (`<input type="range">`) often display a number visually but announce only the number to screen readers, which lacks context (e.g., "60" vs "C4"). Using `aria-valuetext` provides the necessary human-readable context.
+**Action:** Always pair `type="range"` with `aria-valuetext` when the value has a specific unit or mapping (like notes or speed multipliers). Verify using `get_attribute("aria-valuetext")` in Playwright.

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point note"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const octave = Math.floor(midi / 12) - 1;
+    const note = notes[midi % 12];
+    return `${note}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('returns correct note name for C4 (Middle C)', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('returns correct note name for A0 (Piano Lowest)', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('returns correct note name for C8 (Piano Highest)', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('returns correct note name for sharps (C#4)', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('returns correct note name for sharps (F#3)', () => {
+        expect(getNoteName(54)).toBe('F#3');
+    });
+});


### PR DESCRIPTION
💡 What:
- Added `getNoteName` helper in `src/lib/utils.ts` to convert MIDI numbers to scientific pitch notation (e.g., 60 -> C4).
- Updated `src/components/piano/Controls.tsx` to use `getNoteName` for the Split Point visual label.
- Added `aria-valuetext` to the "Split Note" and "Playback Speed" sliders.
- Added `aria-label` to the "Split Note" slider.

🎯 Why:
- The previous Split Point label incorrectly assumed all notes were 'C' (e.g., "61 (C4)" instead of "C#4").
- Screen readers announced raw numbers ("60", "1.5") without context. Now they announce "C4" and "1.5x speed".

📸 Before/After:
- Before: Label "61 (C4)", Screen Reader "61"
- After: Label "61 (C#4)", Screen Reader "C#4"

♿ Accessibility:
- Significantly improved experience for screen reader users on range sliders.
- Fixed misleading visual label for split point.

---
*PR created automatically by Jules for task [10440426783309771940](https://jules.google.com/task/10440426783309771940) started by @pimooss*