### PR TITLE
🎨 Palette: Improve accessibility of Control sliders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Range Slider Accessibility
+**Learning:** Range inputs (<input type="range">) in this codebase often lack `aria-valuetext`, leaving screen reader users with raw numbers (e.g., "60", "1") instead of meaningful values (e.g., "C4", "1.0x speed").
+**Action:** When adding or modifying sliders, always implement `aria-valuetext` to provide human-readable context.

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{getNoteName(visualSettings.splitPoint)} ({visualSettings.splitPoint})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const noteIndex = midi % 12;
+    const note = notes[noteIndex];
+    const octave = Math.floor(midi / 12) - 1;
+    return `${note}${octave}`;
+};

--- a/tests/unit/getNoteName.test.ts
+++ b/tests/unit/getNoteName.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName } from '../../src/lib/utils';
+
+describe('getNoteName', () => {
+    it('returns C4 for MIDI 60', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('returns C#4 for MIDI 61', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('returns A0 for MIDI 21 (lowest piano key)', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('returns C8 for MIDI 108 (highest piano key)', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('handles negative octaves', () => {
+        expect(getNoteName(0)).toBe('C-1');
+    });
+});


### PR DESCRIPTION
🎨 **Palette Check-in**

**What I did:**
- Added `getNoteName` helper to `src/lib/utils.ts` to convert MIDI numbers to note names (e.g., 60 -> C4).
- Updated the "Split Point" slider in `Controls.tsx` to use this helper, fixing a visual bug where all notes were labeled as "C".
- Added `aria-valuetext` to both the "Split Point" and "Playback Speed" sliders.

**Why:**
- **Accessibility:** Screen reader users previously heard raw numbers (e.g., "60"). Now they hear "C4" or "1.5x speed".
- **Usability:** The visual label for the split point was misleading (hardcoded "C"). It now correctly identifies the split note (e.g., "C#4").

**Verification:**
- ✅ Unit tests added for `getNoteName`.
- ✅ Playwright verification confirmed the UI updates and ARIA attributes work as expected.
- ✅ Existing tests passed.

---
*PR created automatically by Jules for task [15685824513066310073](https://jules.google.com/task/15685824513066310073) started by @pimooss*