### PR TITLE
🎨 Palette: Improve slider accessibility and fix split point label

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Range Slider Accessibility
+**Learning:** Range sliders for musical values (like MIDI numbers or playback speed) are often inaccessible because they announce raw numbers (e.g., "60" or "1.5") instead of meaningful values (e.g., "C4" or "1.5x speed").
+**Action:** Always implement `aria-valuetext` on `<input type="range">` elements when the raw numeric value is not the most meaningful representation for the user.

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { Timeline } from "./Timeline";
 
@@ -267,6 +267,7 @@ export function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className="w-full cursor-pointer h-4 md:h-2 bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none"
                             />
                         </div>
@@ -322,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -330,6 +331,8 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const octave = Math.floor(midi / 12) - 1;
+    const noteName = notes[midi % 12];
+    return `${noteName}${octave}`;
+};

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteName, formatTime } from '../../src/lib/utils';
+
+describe('utils', () => {
+  describe('getNoteName', () => {
+    it('correctly converts MIDI numbers to note names', () => {
+      expect(getNoteName(60)).toBe('C4');
+      expect(getNoteName(61)).toBe('C#4');
+      expect(getNoteName(69)).toBe('A4');
+      expect(getNoteName(21)).toBe('A0');
+      expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('handles negative octaves', () => {
+      expect(getNoteName(12)).toBe('C0');
+      expect(getNoteName(0)).toBe('C-1');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('formats seconds correctly', () => {
+      expect(formatTime(0)).toBe('0:00');
+      expect(formatTime(61)).toBe('1:01');
+      expect(formatTime(3599)).toBe('59:59');
+    });
+
+    it('handles invalid inputs', () => {
+        expect(formatTime(-1)).toBe('0:00');
+        expect(formatTime(NaN)).toBe('0:00');
+    });
+  });
+});


### PR DESCRIPTION
💡 What: Added `aria-valuetext` to playback speed and split point sliders. Fixed the visual label for "Split Note" to correctly display the note name (e.g., "C#4") instead of always "C".
🎯 Why: Users using screen readers were hearing raw numbers. The visual label for split point was incorrectly showing "C" for all notes.
♿ Accessibility: Added proper ARIA attributes to sliders.

---
*PR created automatically by Jules for task [18216055780258184613](https://jules.google.com/task/18216055780258184613) started by @pimooss*