### PR TITLE
🎨 Palette: Improve Split Point slider accessibility and feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-10-26 - [Range Sliders for Music Notes]
+**Learning:** Range inputs (`<input type="range">`) that control musical values (like split points or pitch) are inaccessible if they only announce numbers (e.g., "60"). Screen reader users need the semantic note name (e.g., "C4").
+**Action:** Always add `aria-valuetext={getNoteName(value)}` to range sliders representing musical notes to ensure the announcement matches the visual label.

--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { Timeline } from "./Timeline";
@@ -323,7 +323,7 @@ export function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -331,6 +331,7 @@ export function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const octave = Math.floor(midi / 12) - 1;
+    const note = NOTES[midi % 12];
+    return `${note}${octave}`;
+};

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTime } from '../../src/lib/utils';
+import { formatTime, getNoteName } from '../../src/lib/utils';
 
 describe('formatTime', () => {
     it('formats 0 seconds correctly', () => {
@@ -32,5 +32,31 @@ describe('formatTime', () => {
 
     it('handles NaN safely', () => {
         expect(formatTime(NaN)).toBe('0:00');
+    });
+});
+
+describe('getNoteName', () => {
+    it('converts Middle C (60) to C4', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('converts A0 (21) correctly', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('converts C8 (108) correctly', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('handles sharps correctly (61 -> C#4)', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('handles sharps correctly (66 -> F#4)', () => {
+        expect(getNoteName(66)).toBe('F#4');
+    });
+
+    it('handles negative octaves (0 -> C-1)', () => {
+        expect(getNoteName(0)).toBe('C-1');
     });
 });


### PR DESCRIPTION
This PR improves the accessibility and usability of the "Split Point" slider in the settings menu.

**Changes:**
1.  **Accessibility:** Added `aria-valuetext` to the range slider so screen readers announce the actual note name (e.g., "C4", "F#3") instead of just the MIDI number (e.g., "60").
2.  **Visual Clarity:** Updated the visual label to dynamically display the correct note name using the new helper, fixing a previous issue where non-C notes were potentially mislabeled or generic.
3.  **Code Quality:** Added a reusable `getNoteName` helper in `src/lib/utils.ts` and associated unit tests.

**Verification:**
-   **Tests:** `npm run test` passed (14 tests).
-   **Visual:** Verified using Playwright screenshot that the settings panel renders correctly with the note label.
-   **Build:** `npm run build` passed.
-   **Lint:** `npm run lint` passed.

---
*PR created automatically by Jules for task [9785526209277524242](https://jules.google.com/task/9785526209277524242) started by @pimooss*