### PR TITLE
🎨 Palette: Improve split point display and accessibility

### DIFF
--- a/src/components/piano/Controls.tsx
+++ b/src/components/piano/Controls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, memo } from "react";
-import { formatTime } from "@/lib/utils";
+import { formatTime, getNoteName } from "@/lib/utils";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { Timeline } from "./Timeline";
@@ -268,6 +268,7 @@ export const Controls = memo(function Controls({
                                 value={playbackRate}
                                 onChange={(e) => onSetPlaybackRate(parseFloat(e.target.value))}
                                 aria-label="Playback speed"
+                                aria-valuetext={`${playbackRate.toFixed(1)}x speed`}
                                 className={`w-full cursor-pointer bg-zinc-700 rounded-lg appearance-none accent-indigo-600 touch-none ${isTouch ? 'h-4' : 'h-2'}`}
                             />
                         </div>
@@ -323,7 +324,7 @@ export const Controls = memo(function Controls({
                                             <div className="pt-1 space-y-1">
                                                 <div className="flex justify-between text-xs text-zinc-400">
                                                     <span>Split Note</span>
-                                                    <span>{visualSettings.splitPoint} (C{Math.floor(visualSettings.splitPoint / 12) - 1})</span>
+                                                    <span>{visualSettings.splitPoint} ({getNoteName(visualSettings.splitPoint)})</span>
                                                 </div>
                                                 <input
                                                     type="range"
@@ -331,6 +332,8 @@ export const Controls = memo(function Controls({
                                                     max={108}
                                                     value={visualSettings.splitPoint}
                                                     onChange={(e) => visualSettings.setSplitPoint(parseInt(e.target.value))}
+                                                    aria-label="Split point note"
+                                                    aria-valuetext={getNoteName(visualSettings.splitPoint)}
                                                     className="w-full h-1 bg-zinc-700 rounded-lg appearance-none accent-indigo-500"
                                                 />
                                             </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ export const formatTime = (seconds: number): string => {
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;
 };
+
+export const getNoteName = (midi: number): string => {
+    const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const octave = Math.floor(midi / 12) - 1;
+    const noteName = NOTES[midi % 12];
+    return `${noteName}${octave}`;
+};

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTime } from '../../src/lib/utils';
+import { formatTime, getNoteName } from '../../src/lib/utils';
 
 describe('formatTime', () => {
     it('formats 0 seconds correctly', () => {
@@ -32,5 +32,27 @@ describe('formatTime', () => {
 
     it('handles NaN safely', () => {
         expect(formatTime(NaN)).toBe('0:00');
+    });
+});
+
+describe('getNoteName', () => {
+    it('converts MIDI 60 to C4', () => {
+        expect(getNoteName(60)).toBe('C4');
+    });
+
+    it('converts MIDI 21 to A0', () => {
+        expect(getNoteName(21)).toBe('A0');
+    });
+
+    it('converts MIDI 108 to C8', () => {
+        expect(getNoteName(108)).toBe('C8');
+    });
+
+    it('handles sharp notes (e.g. 61 -> C#4)', () => {
+        expect(getNoteName(61)).toBe('C#4');
+    });
+
+    it('handles low notes (e.g. 0 -> C-1)', () => {
+        expect(getNoteName(0)).toBe('C-1');
     });
 });


### PR DESCRIPTION
This PR addresses a UX issue where the split point slider displayed raw MIDI numbers or incorrect note names (always starting with 'C'). It introduces a `getNoteName` utility to correctly format MIDI notes to scientific pitch notation (e.g., C#4). This utility is used in the UI to display the note name next to the slider value. Additionally, `aria-valuetext` attributes were added to both the split point and playback speed sliders to provide meaningful context for screen reader users (e.g., "1.5x speed" instead of just "1.5"). Unit tests for the new utility were added to `tests/unit/utils.test.ts`.

---
*PR created automatically by Jules for task [18000956259608406621](https://jules.google.com/task/18000956259608406621) started by @pimooss*