### PR TITLE
fix: persist playback state and fix iOS layout (#112, #113)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 export const metadata: Metadata = {
   title: "Piano Lessons",
   description: "Learn to play piano with interactive lessons",
+};
+
+export const viewport: Viewport = {
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/src/lib/audio-logic.ts
+++ b/src/lib/audio-logic.ts
@@ -1,11 +1,12 @@
+export const BASE_PIANO_WIDTH = 1248 + 48; // 1296
 
 /**
  * Logic for calculating the scale factor of the piano keyboard
  * to fit within the available screen width.
  */
-export function calculateKeyboardScale(windowWidth: number, basePianoWidth: number = 1248 + 48): number {
+export function calculateKeyboardScale(windowWidth: number, basePianoWidth: number = BASE_PIANO_WIDTH): number {
   if (windowWidth < basePianoWidth) {
-    return Math.max(0.5, windowWidth / basePianoWidth);
+    return windowWidth / basePianoWidth;
   }
   return 1;
 }

--- a/tests/unit/audio-logic.test.ts
+++ b/tests/unit/audio-logic.test.ts
@@ -19,8 +19,8 @@ describe('Audio and UI Logic', () => {
       expect(scale).toBe(iPadWidth / BASE_WIDTH);
     });
 
-    it('should not scale below 0.5', () => {
-      expect(calculateKeyboardScale(300)).toBe(0.5);
+    it('should scale proportionally for very small widths', () => {
+      expect(calculateKeyboardScale(300)).toBeCloseTo(300 / BASE_WIDTH);
     });
   });
 


### PR DESCRIPTION
## Summary
- **#113**: Playback speed and per-song position are now persisted to localStorage, so exiting and re-entering a lesson restores where you left off at the same speed
- **#112**: Fixes iPhone/iPad layout — removes the 0.5 scale floor so the keyboard always fits the viewport, adds CSS height compensation so the keyboard reaches the bottom, switches to `overflow-hidden`, and adds `viewport-fit: cover` for iOS safe areas

## Changes
- `usePianoAudio.ts`: Accept `initialPlaybackRate` and `initialTick` settings; restore position after MIDI loads
- `page.tsx`: Add localStorage helpers for rate/position; persist on change and unmount; fix scaled container (height compensation, overflow-hidden)
- `audio-logic.ts`: Export `BASE_PIANO_WIDTH`; remove `Math.max(0.5, ...)` scale clamp
- `layout.tsx`: Add `Viewport` export with `viewportFit: 'cover'`
- `audio-logic.test.ts`: Update test for removed scale clamp

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint clean (`npm run lint`)
- [ ] Unit tests pass (`npm test -- --run`)
- [x] Select a song, change speed to 0.5×, play partway, exit to song list, re-enter — position and speed restored
- [ ] Chrome DevTools mobile emulation (iPhone 12, iPad, iPhone SE landscape) — keyboard anchored at bottom, no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)