### PR TITLE
fix(vfx): ensure particles trigger on consecutive notes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -254,7 +254,7 @@ function PianoLesson({ song, allSongs, onSongChange, onExit }: PianoLessonProps)
     return audio.activeNotes.map(activeNote => {
       const midiNumber = Tone.Frequency(activeNote.note).toMidi();
       const trackColor = getNoteColor(activeNote.track, midiNumber, colors, splitSettings);
-      return { note: activeNote.note, color: trackColor };
+      return { note: activeNote.note, color: trackColor, startTick: activeNote.startTick };
     });
   }, [audio.activeNotes, splitHands, leftColor, rightColor, unifiedColor, splitStrategy, splitPoint]);
 
@@ -264,6 +264,7 @@ function PianoLesson({ song, allSongs, onSongChange, onExit }: PianoLessonProps)
       note: ck.note,
       midi: Tone.Frequency(ck.note).toMidi(),
       color: ck.color,
+      startTick: ck.startTick,
     }));
   }, [coloredKeys]);
 

--- a/src/hooks/usePianoAudio.ts
+++ b/src/hooks/usePianoAudio.ts
@@ -12,6 +12,10 @@ export interface ActiveNote {
     note: string;
     track: number;
     velocity: number;
+    /** 
+     * Timestamp (in ticks) when this note started. 
+     * Used by EffectsEngine to distinguish separate attacks of the same pitch. 
+     */
     startTick: number;
 }
 

--- a/src/hooks/usePianoAudio.ts
+++ b/src/hooks/usePianoAudio.ts
@@ -12,6 +12,7 @@ export interface ActiveNote {
     note: string;
     track: number;
     velocity: number;
+    startTick: number;
 }
 
 export interface PreviewNote {
@@ -122,7 +123,12 @@ export function usePianoAudio(source: SongSource, settings: PianoAudioSettings =
             events.forEach(event => {
                 const key = `${event.note} -${event.track} `;
                 if (event.type === 'start') {
-                    activeNotesRef.current.set(key, { note: event.note, track: event.track, velocity: event.velocity });
+                    activeNotesRef.current.set(key, {
+                        note: event.note,
+                        track: event.track,
+                        velocity: event.velocity,
+                        startTick: tick
+                    });
                 } else {
                     activeNotesRef.current.delete(key);
                 }
@@ -368,7 +374,12 @@ export function usePianoAudio(source: SongSource, settings: PianoAudioSettings =
                             events.forEach(event => {
                                 const key = `${event.note} -${event.track} `;
                                 if (event.type === 'start') {
-                                    activeNotesRef.current.set(key, { note: event.note, track: event.track, velocity: event.velocity });
+                                    activeNotesRef.current.set(key, {
+                                        note: event.note,
+                                        track: event.track,
+                                        velocity: event.velocity,
+                                        startTick: tick
+                                    });
                                     triggerHitstop = true;
                                     newCount++;
                                     if (event.velocity > maxV) maxV = event.velocity;

--- a/src/lib/effects-engine.ts
+++ b/src/lib/effects-engine.ts
@@ -239,7 +239,10 @@ export class EffectsEngine {
      * The React wrapper should call this whenever activeNotes change.
      */
     emitForNewNotes(notes: EffectsNote[]): void {
-        // Use composite key to allow re-triggering of same note at different time
+        // Use composite key (`${midi}-${startTick}`) instead of just `${midi}`.
+        // This is critical for detecting consecutive or rapid repetitions of the same note.
+        // Without `startTick`, the engine incorrectly sees the note as "already active" 
+        // and skips the particle burst/shockwave trigger.
         const currentKeys = new Set(notes.map((n) => `${n.midi}-${n.startTick}`));
         const prevKeys = this.prevNotes;
         const now = performance.now();

--- a/src/lib/effects-engine.ts
+++ b/src/lib/effects-engine.ts
@@ -6,11 +6,11 @@
 
 import { ParticleSystem } from "@/lib/particles";
 import { getKeyPosition, getTotalKeyboardWidth } from "@/components/piano/geometry";
-import { 
-    GOD_RAY_WIDTH, 
-    GOD_RAY_OPACITY_BASE, 
-    GOD_RAY_OPACITY_VARY, 
-    BLOOM_BURST_THRESHOLD 
+import {
+    GOD_RAY_WIDTH,
+    GOD_RAY_OPACITY_BASE,
+    GOD_RAY_OPACITY_VARY,
+    BLOOM_BURST_THRESHOLD
 } from "@/lib/vfx-constants";
 
 // ---------------------------------------------------------------------------
@@ -21,6 +21,7 @@ export interface EffectsNote {
     note: string;
     midi: number;
     color: string;
+    startTick: number; // Unique ID for VFX
 }
 
 // ---------------------------------------------------------------------------
@@ -109,8 +110,8 @@ function shiftHue(
                 Math.max(
                     0,
                     r * (0.667 + cos * 0.333) +
-                        g * (0.333 - cos * 0.333 + sin * 0.577) +
-                        b * (0.333 - cos * 0.333 - sin * 0.577),
+                    g * (0.333 - cos * 0.333 + sin * 0.577) +
+                    b * (0.333 - cos * 0.333 - sin * 0.577),
                 ),
             ),
         ),
@@ -120,8 +121,8 @@ function shiftHue(
                 Math.max(
                     0,
                     r * (0.333 - cos * 0.333 - sin * 0.577) +
-                        g * (0.667 + cos * 0.333) +
-                        b * (0.333 - cos * 0.333 + sin * 0.577),
+                    g * (0.667 + cos * 0.333) +
+                    b * (0.333 - cos * 0.333 + sin * 0.577),
                 ),
             ),
         ),
@@ -131,8 +132,8 @@ function shiftHue(
                 Math.max(
                     0,
                     r * (0.333 - cos * 0.333 + sin * 0.577) +
-                        g * (0.333 - cos * 0.333 - sin * 0.577) +
-                        b * (0.667 + cos * 0.333),
+                    g * (0.333 - cos * 0.333 - sin * 0.577) +
+                    b * (0.667 + cos * 0.333),
                 ),
             ),
         ),
@@ -238,13 +239,14 @@ export class EffectsEngine {
      * The React wrapper should call this whenever activeNotes change.
      */
     emitForNewNotes(notes: EffectsNote[]): void {
-        const currentKeys = new Set(notes.map((n) => `${n.midi}`));
+        // Use composite key to allow re-triggering of same note at different time
+        const currentKeys = new Set(notes.map((n) => `${n.midi}-${n.startTick}`));
         const prevKeys = this.prevNotes;
         const now = performance.now();
 
         // --- Emit particles + impact flash for new note-ons ---
         for (const n of notes) {
-            const key = `${n.midi}`;
+            const key = `${n.midi}-${n.startTick}`;
             if (!prevKeys.has(key)) {
                 const { left, width } = getKeyPosition(n.midi);
                 const centerX = left + width / 2;
@@ -478,7 +480,7 @@ export class EffectsEngine {
         const atmosphereColor = THEME_ATMOSPHERE[this.theme] || THEME_ATMOSPHERE.cool;
         const parsed = parseColor(atmosphereColor)!;
         const shimmer = 0.5 + 0.5 * Math.sin(time * 0.001);
-        
+
         // Render 3 distinct diagonal rays
         const rayWidth = GOD_RAY_WIDTH;
         const rays = [
@@ -495,12 +497,12 @@ export class EffectsEngine {
             grad.addColorStop(1, `rgba(${parsed.r}, ${parsed.g}, ${parsed.b}, 0)`);
 
             ctx.fillStyle = grad;
-            
+
             ctx.beginPath();
-            ctx.moveTo(ray.x - rayWidth/2, 0);
-            ctx.lineTo(ray.x + rayWidth/2, 0);
-            ctx.lineTo(ray.x + rayWidth/2 + Math.tan(ray.angle) * this.containerHeight, this.containerHeight);
-            ctx.lineTo(ray.x - rayWidth/2 + Math.tan(ray.angle) * this.containerHeight, this.containerHeight);
+            ctx.moveTo(ray.x - rayWidth / 2, 0);
+            ctx.lineTo(ray.x + rayWidth / 2, 0);
+            ctx.lineTo(ray.x + rayWidth / 2 + Math.tan(ray.angle) * this.containerHeight, this.containerHeight);
+            ctx.lineTo(ray.x - rayWidth / 2 + Math.tan(ray.angle) * this.containerHeight, this.containerHeight);
             ctx.fill();
         });
 


### PR DESCRIPTION
# Fix: Trigger VFX for Consecutive/Repeated Notes

## Summary
Fixed a visual bug where particle effects and shockwaves failed to trigger for consecutive or repeated notes of the same pitch. The `EffectsEngine` now uniquely identifies note instances using their start time (`startTick`) rather than just their MIDI pitch.

## Changes

### 1. Unique Note Identification
-   **[MODIFY] `src/hooks/usePianoAudio.ts`**:
    -   Updated `ActiveNote` interface to include `startTick`.
    -   Modified `syncLoop` and `rebuildActiveNotes` to capture the `tick` when a note starts.

### 2. Data Propagation
-   **[MODIFY] `src/app/page.tsx`**:
    -   Propagated `startTick` from `audio.activeNotes` to `effectsNotes`, ensuring the `EffectsCanvas` receives this data.

### 3. Engine Update
-   **[MODIFY] `src/lib/effects-engine.ts`**:
    -   Updated `EffectsNote` interface.
    -   Modified `emitForNewNotes` to key off `${midi}-${startTick}` instead of just `${midi}`.
    -   This allows the engine to detect a "new" note even if the MIDI pitch is identical to the previous frame (e.g., fast repetitions).

## Verification
-   **Manual Test**: Confirmed that hitting the same key repeatedly now triggers a fresh particle burst and shockwave for *every* press.
-   **Build**: `npm run build` passed successfully.
