### PR TITLE
docs: add 0.6.0 changelog and fix stale documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-02-18
+
+### Added
+- VFX Phase 2: per-theme lighting, texture & colour identity with data-driven profiles (`THEME_VFX_PROFILES`, `THEME_PARTICLE_BEHAVIORS`, `THEME_COLOR_GRADES` in `vfx-constants.ts`)
+- VFX Phase 3: post-processing & juice — fullscreen vignette, ordered dithering on panels, specular highlights on black keys, and particle physics (gravity, drag, spin)
+- Loading overlay with audio prefetch on song select to eliminate the "notes appear late" delay on first play
+- Salamander Grand Piano samples bundled locally — no external CDN dependency at runtime
+- Self-hosted fonts via `@fontsource` — eliminates Google Fonts network request
+- 8 new beginner/intermediate scores in MusicXML format (Beethoven, Bach, Mozart, Chopin, and more)
+- MusicXML duration pre-computation with a sort dropdown on the song list (by title / duration)
+- PR preview deployments via Cloudflare Pages: preview URL auto-posted as a PR comment, deployment cleaned up on PR close
+
+### Fixed
+- MusicXML multi-voice / grand-staff timing: switched parser to `preserveOrder: true` so `<backup>`/`<forward>` elements are processed in document order — fixes completely wrong note timing on all grand-staff pieces
+- MusicXML staff-aware hand colouring: uses `-staff1`/`-staff2` track-name suffix instead of raw track index, so right/left hand colours survive MIDI layer splitting
+- VFX particles not triggering on consecutive notes of the same pitch
+- White key cutout depth (`cutH`) misaligned with black key bottom edge — exposed white key edges below black keys
+- iPhone / iPad keyboard centering regression and missing first note on load
+- Landing page vertical alignment and iOS install-hint overlay positioning in screenshots
+
+### Changed
+- CSP header tightened: fonts and piano samples now served from same origin, removing external CDN entries from `connect-src` / `font-src`
+- Hand colour pickers removed from Settings — note colours are now fully defined by the active theme
+
 ## [0.5.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Piano Lessons is an interactive web app for learning piano via a "Guitar Hero" style falling-notes waterfall synchronized with audio playback. It uses Next.js 16 with static export, deployed to GitHub Pages.
+Piano Lessons is an interactive web app for learning piano via a "Guitar Hero" style falling-notes waterfall synchronized with audio playback. It uses Next.js 16 with static export, deployed to GitHub Pages. PR preview deployments run on Cloudflare Pages (branch `pr-<N>`) and are cleaned up automatically on PR close.
 
 ## Commands
 
@@ -48,6 +48,7 @@ Local `useState` for UI state, refs for mutable Tone.js references, `useSyncExte
 ## Critical Configuration
 
 - **basePath**: `/piano_lessons` in `next.config.ts` — all local URLs must include this prefix
+- **`NEXT_PUBLIC_BASE_PATH` env var**: overrides the basePath for asset URLs at build time. Set to `''` (empty string) in the Cloudflare Pages preview build so assets resolve from the root. Leave unset for the normal GitHub Pages build.
 - **Static export**: `output: "export"` — no server-side features (no API routes, no SSR)
 - **React Compiler**: Enabled (`reactCompiler: true`) — automatic memoization via `babel-plugin-react-compiler`. **WARNING:** The compiler (Turbopack/SWC) generates internal dependency arrays for `useEffect`/`useCallback` at compile time. Any code change that alters the compiler's dependency analysis (adding new local variables, `for` loops, or function calls inside effect/callback bodies) can change the internal array size, causing the runtime error: _"The final argument passed to useEffect changed size between renders."_ The `"use no memo"` opt-out directive is **not recognized** by this Turbopack integration. Safe changes: modifying numeric literals and math formulas using only already-captured variables. Unsafe: adding new control flow, new `useRef` hooks, or referencing new variables inside effects. For complex changes to `EffectsCanvas.tsx`, consider migrating to the imperative `EffectsEngine` class (`src/lib/effects-engine.ts`) which bypasses the compiler entirely.
 - **CSS `contain: paint` clips `box-shadow`**: Waterfall notes (`.waterfall-note`) use `contain: layout style` — do NOT add `paint` containment. `contain: paint` clips all outer `box-shadow` overflow, making glow effects completely invisible. This was a long-standing silent bug that hid every visual change to note styling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ npm install
 
 # Start development server
 npm run dev
-# App runs at http://localhost:3000
+# App runs at http://localhost:3000/piano_lessons
 
 # Build for production
 npm run build
@@ -63,13 +63,13 @@ This will:
 - New visual features (e.g., new color themes)
 - Major layout updates
 
-66: ## Pull Request Workflow
-67: 
-68: 1. **Fork & Branch:** Create a feature branch from `main`.
-69: 2. **Implement:** Write clean, typed code.
-70: 3. **Test:** Ensure `npm run build` and `npm run lint` pass locally.
-71: 4. **Verify Pipelines:** Push your branch and **WAIT** for the CI pipeline to pass on your fork/branch. Fix any deployment or build errors *before* opening a PR or marking it as ready for review.
-72: 5. **Submit:** Open a PR describing your changes.
+## Pull Request Workflow
+
+1. **Fork & Branch:** Create a feature branch from `main`.
+2. **Implement:** Write clean, typed code.
+3. **Test:** Ensure `npm run build` and `npm run lint` pass locally.
+4. **Verify Pipelines:** Push your branch and **WAIT** for the CI pipeline to pass. Fix any build or lint errors *before* opening a PR or marking it as ready for review.
+5. **Submit:** Open a PR describing your changes. A Cloudflare Pages preview URL will be automatically posted as a comment so you can verify the live build before merging.
 
 ## Code Style
 


### PR DESCRIPTION
- CHANGELOG.md: add [0.6.0] entry covering VFX Phase 2 & 3, MusicXML polyphony fix, 8 new scores, Salamander bundling, self-hosted fonts, CSP tightening, and Cloudflare Pages PR previews
- CLAUDE.md: note Cloudflare Pages PR preview deployment in overview; document NEXT_PUBLIC_BASE_PATH env var in Critical Configuration
- CONTRIBUTING.md: fix dev URL (was missing /piano_lessons basePath); remove embedded line numbers from PR workflow section; mention Cloudflare preview URL posted automatically on PR open

https://claude.ai/code/session_016VRw7k2pX4SAGMid997doJ

## Description

Please include a summary of the change and which issue is fixed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Manual verification in browser

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
