### PR TITLE
fix: menu sounds broken on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { ToastContainer, showToast } from "@/components/Toast";
 import { EffectsCanvas, EffectsNote } from "@/components/piano/EffectsCanvas";
 import { abcToMidiBuffer } from "@/lib/abc-loader";
-import { playHoverSound, playSelectSound } from "@/lib/menu-sounds";
+import { playHoverSound, playSelectSound, warmUpAudio } from "@/lib/menu-sounds";
 import { Midi } from "@tonejs/midi";
 import * as Tone from "tone";
 
@@ -603,6 +603,9 @@ export default function Home() {
       setTimeout(() => setShowSilentModeHint(true), 0);
     }
   }, []);
+
+  // Unlock AudioContext on first user activation so hover sounds work immediately after
+  useEffect(() => { warmUpAudio(); }, []);
 
   const selectSong = useCallback(async (song: Song) => {
     try {

--- a/src/lib/menu-sounds.ts
+++ b/src/lib/menu-sounds.ts
@@ -1,40 +1,62 @@
-import * as Tone from "tone";
-
-let synth: Tone.Synth | null = null;
+let ctx: AudioContext | null = null;
 let lastPlayTime = 0;
-const THROTTLE_MS = 100;
+const THROTTLE_MS = 80;
 
-function getSynth(): Tone.Synth | null {
-  if (Tone.context.state !== 'running') return null;
-  if (!synth) {
-    synth = new Tone.Synth({
-      oscillator: { type: 'square' },
-      envelope: { attack: 0.005, decay: 0.05, sustain: 0, release: 0.02 },
-      volume: -24,
-    }).toDestination();
+function ensureContext(): AudioContext | null {
+  if (!ctx) {
+    try {
+      ctx = new AudioContext();
+    } catch {
+      return null;
+    }
   }
-  return synth;
+  if (ctx.state === 'suspended') {
+    ctx.resume().catch(() => {});
+  }
+  return ctx.state === 'running' ? ctx : null;
 }
 
-function canPlay(): boolean {
-  const now = Date.now();
-  if (now - lastPlayTime < THROTTLE_MS) return false;
+/**
+ * Eagerly create and resume the AudioContext on the first user activation
+ * (click, keydown, etc.) so hover sounds work immediately after.
+ * mouseenter/mouseover are NOT user activation events, so hover alone
+ * can never unlock audio — this is a browser restriction.
+ */
+export function warmUpAudio() {
+  const unlock = () => {
+    ensureContext();
+    for (const evt of ['click', 'keydown', 'touchend'] as const) {
+      document.removeEventListener(evt, unlock, true);
+    }
+  };
+  for (const evt of ['click', 'keydown', 'touchend'] as const) {
+    document.addEventListener(evt, unlock, { capture: true, once: false });
+  }
+}
+
+function beep(frequency: number, duration: number) {
+  const now = performance.now();
+  if (now - lastPlayTime < THROTTLE_MS) return;
   lastPlayTime = now;
-  return true;
+
+  const c = ensureContext();
+  if (!c) return;
+
+  const osc = c.createOscillator();
+  const gain = c.createGain();
+  osc.type = 'square';
+  osc.frequency.value = frequency;
+  gain.gain.value = 0.04;
+  gain.gain.exponentialRampToValueAtTime(0.001, c.currentTime + duration);
+  osc.connect(gain).connect(c.destination);
+  osc.start(c.currentTime);
+  osc.stop(c.currentTime + duration);
 }
 
 export function playHoverSound() {
-  if (!canPlay()) return;
-  const s = getSynth();
-  if (s) {
-    s.triggerAttackRelease('C6', '32n');
-  }
+  beep(1047, 0.03); // C6
 }
 
 export function playSelectSound() {
-  if (!canPlay()) return;
-  const s = getSynth();
-  if (s) {
-    s.triggerAttackRelease('E6', '16n');
-  }
+  beep(1319, 0.06); // E6
 }


### PR DESCRIPTION
## Summary
- **Replaced Tone.js with raw Web Audio API** for menu hover/select sounds — Tone.js AudioContext was never initialized on the landing page, so `getSynth()` always returned null
- **Added `warmUpAudio()`** that eagerly unlocks the AudioContext on the first user activation event (click/keydown/touchend), so hover sounds work immediately after
- **Eliminated race condition** causing "Start time must be strictly greater than previous start time" errors when multiple async hover events queued up

## Context
Browser autoplay policy requires a user activation event before an AudioContext can start. `mouseenter` is **not** a user activation event, so hover sounds can never be the first thing to unlock audio. The warmup listener ensures the context is ready after the very first click/keypress anywhere on the page.

## Test plan
- [x] Open landing page, hover over songs — no console errors
- [x] Click anywhere on the page, then hover over songs — hear hover beep sounds
- [x] Click a song — hear select beep sound
- [ ] Verify on Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)